### PR TITLE
Fix type defs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { ModelRegistry } from "ember-data";
+import DS, { ModelRegistry, TransformRegistry } from "ember-data";
 
 /**
  * Decorator that turns the property into an Ember Data attribute
@@ -15,40 +15,11 @@ import { ModelRegistry } from "ember-data";
  * @function
  * @param {String} [type] - Type of the attribute
  */
-export function attr(): PropertyDecorator;
-/**
- * Decorator that turns the property into an Ember Data attribute
- *
- * ```javascript
- * import Model from 'ember-data/model';
- * import { attr } from 'ember-decorators/data';
- *
- * export default Model.extend({
- *   @attr firstName: null
- * });
- * ```
- *
- * @function
- * @param {String} [type] - Type of the attribute
- */
-export function attr<K extends keyof ModelRegistry>(type: K): PropertyDecorator;
+export function attr<K extends keyof TransformRegistry>(
+  type?: K,
+  options?: DS.AttrOptions<TransformRegistry[K]>,
+): PropertyDecorator;
 
-/**
- * Decorator that turns the property into an Ember Data `hasMany` relationship
- *
- * ```javascript
- * import Model from 'ember-data/model';
- * import { hasMany } from 'ember-decorators/data';
- *
- * export default Model.extend({
- *   @hasMany users: null
- * });
- * ```
- *
- * @function
- * @param {String} [type] - Type of the `hasMany` relationship
- */
-export function hasMany(): PropertyDecorator;
 /**
  * Decorator that turns the property into an Ember Data `hasMany` relationship
  *
@@ -65,7 +36,8 @@ export function hasMany(): PropertyDecorator;
  * @param {String} [type] - Type of the `hasMany` relationship
  */
 export function hasMany<K extends keyof ModelRegistry>(
-  type: K
+  type?: K,
+  options?: DS.RelationshipOptions<ModelRegistry[K]>
 ): PropertyDecorator;
 
 /**
@@ -82,20 +54,7 @@ export function hasMany<K extends keyof ModelRegistry>(
  * @function
  * @param {String} [type] - Type of the `belongsTo` relationship
  */
-export function belongsTo(): PropertyDecorator;
-/**
- * Decorator that turns the property into an Ember Data `belongsTo` relationship
- *
- * ```javascript
- * import Model from 'ember-data/model';
- * import { belongsTo } from 'ember-decorators/data';
- *
- * export default Model.extend({
- *   @belongsTo user: null
- * });
- * ```
- * @function
- * @param {String} [type] - Type of the `belongsTo` relationship
- */ export function belongsTo<K extends keyof ModelRegistry>(
-  type?: K
+export function belongsTo<K extends keyof ModelRegistry>(
+  type?: K,
+  options?: DS.RelationshipOptions<ModelRegistry[K]>
 ): PropertyDecorator;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@ember-decorators/babel-transforms": "^2.0.0",
     "@types/ember": "^2.8.12",
-    "@types/ember-data": "^2.14.9",
+    "@types/ember-data": "^2.14.17",
     "@types/ember-test-helpers": "^0.7.1",
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,9 +63,9 @@
     ember-cli-babel "^6.6.0"
     ember-cli-version-checker "^2.1.0"
 
-"@ember-decorators/utils@^2.0.0-beta.4":
-  version "2.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-2.0.0-beta.4.tgz#5e3cf9ecf9dd8c1aacf3bfaea11efdda2833bfbd"
+"@ember-decorators/utils@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-2.0.0.tgz#14f1fbd6de4f1d722b15c155287aafc6453943f2"
   dependencies:
     ember-cli-babel "^6.6.0"
     ember-compatibility-helpers "1.0.0-beta.1"
@@ -92,9 +92,9 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
 
-"@types/ember-data@^2.14.9":
-  version "2.14.9"
-  resolved "https://registry.yarnpkg.com/@types/ember-data/-/ember-data-2.14.9.tgz#eec43843da95be1fd19ec55227a9c5f6b170e734"
+"@types/ember-data@^2.14.17":
+  version "2.14.17"
+  resolved "https://registry.yarnpkg.com/@types/ember-data/-/ember-data-2.14.17.tgz#2395bd3ffcc1f6420ea852e3a83270a2d9a6c174"
   dependencies:
     "@types/rsvp" "*"
 


### PR DESCRIPTION
The TypeScript type defs needed some work. In particular:

* The type argument to `@attr` should extend the `TransformRegistry` instead of the `ModelRegistry`.
* The definitions do not allow for options to be specified.

As of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/25282, `RelationshipOptions` is now available on the DS namespace. `AttrOptions` was previously available, but incomplete. `@types/ember-data@2.14.17` includes these updates.

We're using these exact definitions in a production app [here](https://github.com/CenterForOpenScience/ember-osf-web/blob/develop/types/%40ember-decorators/data.d.ts).